### PR TITLE
Multiple status selection and fix empty task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,6 @@ data.json
 .DS_Store
 pnpm-lock.yaml
 
-build
+build*
 dist
 coverage

--- a/src/components/reusable/Dialog.tsx
+++ b/src/components/reusable/Dialog.tsx
@@ -21,7 +21,7 @@ export const Dialog = (props: DialogProps): React.JSX.Element => {
     React.useEffect(() => {
         window.addEventListener('keydown', handleKeyDown);
 
-        return () => {
+        return (): void => {
             window.removeEventListener('keydown', handleKeyDown);
         };
     }, []);
@@ -38,10 +38,10 @@ export const Dialog = (props: DialogProps): React.JSX.Element => {
         }
 
         if (!isOpen && onClose) {
-            onClose()
+            onClose();
         }
 
-        return () => {
+        return (): void => {
             document.removeEventListener("click", onClick);
         };
     }, [isOpen]);

--- a/src/components/reusable/styles.module.css
+++ b/src/components/reusable/styles.module.css
@@ -17,3 +17,15 @@
 	text-align: center;
 	padding: 0 0.2rem;
 }
+
+.statusCheckboxRow {
+	display: flex;
+	flex-direction: row;
+	gap: 1rem;
+}
+
+.statusCheckboxItem {
+	display: flex;
+	align-items: center;
+	gap: 0.3rem;
+}

--- a/src/components/tabs/Tasks/TaskPanel/Filters/StatusFilter.tsx
+++ b/src/components/tabs/Tasks/TaskPanel/Filters/StatusFilter.tsx
@@ -1,34 +1,43 @@
 import React from "react";
 
 import { StatusKeys } from "@core/consts";
-import { StatusFilterOption } from "@core/types";
+import { Status } from "@core/types";
 import { useFilters } from "@providers/FiltersProvider";
 import styles from "../../../../reusable/styles.module.css";
 
 export default function StatusFilter(): React.JSX.Element {
+	const statusOptions: Array<Status> = StatusKeys;
 	const { status } = useFilters();
+
+	const statusValue = status.value;
+	const setStatus = status.setValue;
 
 	return (
 		<div className="flex-items-center">
-			<select
-				name="status"
-				id="status"
-				className={styles.taskSelectOption}
-				value={status.value}
-				onChange={(e) =>
-					status.setValue(e.currentTarget.value as StatusFilterOption)
-				}
-			>
-				<option value="all">all</option>
 
-				{StatusKeys.map((status) => (
-					<option value={status} key={status}>
-						{status}
-					</option>
-				))}
-			</select>
 
 			<label htmlFor="status">Filter by status</label>
+			{/* Exclude Statuses Checkbox */}
+			<div className={styles.statusCheckboxRow}>
+				{statusOptions.map((s) => (
+					<div key={s} className={styles.statusCheckboxItem}>
+						<input
+							type="checkbox"
+							id={s}
+							name={s}
+							checked={statusValue.includes(s)}
+							onChange={(e) => {
+								const newStatuses = e.target.checked
+									? [...statusValue, s]
+									: statusValue.filter((v) => v !== s);
+								setStatus(newStatuses);
+							}}
+							value={s}
+						/>
+						<label htmlFor={s}>{s}</label>
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/components/tabs/Tasks/TaskPanel/Filters/StatusFilter.tsx
+++ b/src/components/tabs/Tasks/TaskPanel/Filters/StatusFilter.tsx
@@ -14,8 +14,6 @@ export default function StatusFilter(): React.JSX.Element {
 
 	return (
 		<div className="flex-items-center">
-
-
 			<label htmlFor="status">Filter by status</label>
 			{/* Exclude Statuses Checkbox */}
 			<div className={styles.statusCheckboxRow}>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -13,7 +13,7 @@ const DefaultDifficulties = [
 
 export const DEFAULT_SETTINGS: GamifiedTasksSettings = {
     limit: 10,
-    statusFilter: "all",
+    statusFilter: [],
     isRecurTasks: false,
     pathToRewards: "rewards.md",
     pathToHistory: "history.md",

--- a/src/core/consts.ts
+++ b/src/core/consts.ts
@@ -39,12 +39,14 @@ export const StatusMarkdown: Record<Status, string> = {
 	 * Represents a task that has been delayed.
 	 */
 	delay: "?",
+
 };
 
 /**
  * Array of status keys.
  */
 export const StatusKeys = Object.keys(StatusMarkdown) as Array<Status>;
+
 
 /**
  * Gamified Tasks uses middlewares for parsing tasks metadata (tags) and stringifying back to markdown line.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -61,7 +61,7 @@ export type TaskFilters = {
     /**
      * The status filter option for tasks.
      */
-    status: State<StatusFilterOption>;
+    status: State<Array<Status>>;
 
     /**
      * Indicates whether tasks are recurring.

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -83,7 +83,7 @@ export default function useHistory(): UseHistoryReturn {
 		fetchHistory();
 
 		vault.on("modify", fetchHistory);
-		return () => vault.off("modify", fetchHistory);
+		return (): void => vault.off("modify", fetchHistory);
 	}, []);
 
 	return { historyRows, balance, isHistoryParsed, addHistoryRow };

--- a/src/hooks/useRewards.ts
+++ b/src/hooks/useRewards.ts
@@ -57,7 +57,7 @@ export default function useRewards(): UseRewardsReturn {
 		fetchRewards();
 
 		vault.on("modify", fetchRewards);
-		return () => vault.off("modify", fetchRewards);
+		return (): void => vault.off("modify", fetchRewards);
 	}, []);
 
 	return { rewards, isRewardsParsed };

--- a/src/hooks/useWatchTasks/index.ts
+++ b/src/hooks/useWatchTasks/index.ts
@@ -46,7 +46,7 @@ export default function useWatchTasks(): UseTasksResult {
 			syncTasksForUI();
 
 			vault.on("modify", syncTasksForUI);
-			return () => vault.off("modify", syncTasksForUI);
+			return (): void => vault.off("modify", syncTasksForUI);
 		}, []);
 
 		watchUITaskList();

--- a/src/hooks/useWatchTasks/useWatchUITaskList.ts
+++ b/src/hooks/useWatchTasks/useWatchUITaskList.ts
@@ -137,7 +137,7 @@ export default function useWatchUITaskList(): Result {
 			};
 
 			workspace.on("active-leaf-change", handleActiveFile);
-			return () => workspace.off("active-leaf-change", handleActiveFile);
+			return (): void => workspace.off("active-leaf-change", handleActiveFile);
 		}, [
 			...Object.values(filters).map(({ value }) => value),
 			...Object.values(sorting).map(({ value }) => value),

--- a/src/providers/FiltersProvider.tsx
+++ b/src/providers/FiltersProvider.tsx
@@ -1,4 +1,4 @@
-import { StatusFilterOption, TaskFilters } from "@core/types";
+import { Status, StatusFilterOption, TaskFilters } from "@core/types";
 import React from "react";
 
 export const FiltersContext = React.createContext<TaskFilters | undefined>(
@@ -19,10 +19,9 @@ export default function FiltersProvider({
 	children,
 }: React.PropsWithChildren): React.JSX.Element {
 	const [limit, setLimit] = React.useState(0);
-	const [status, setStatus] = React.useState<StatusFilterOption>("all");
+	const [status, setStatus] = React.useState<Array<Status>>([]);
 	const [isRecur, setIsRecur] = React.useState(false);
-	const [shouldShowByCondition, setShouldShowByCondition] =
-		React.useState(false);
+	const [shouldShowByCondition, setShouldShowByCondition] = React.useState(false);
 	const [search, setSearch] = React.useState("");
 	const [tagsFilter, setTagsFilter] = React.useState("");
 	const [hasOnlyThisTags, setHasOnlyThisTags] = React.useState(false);

--- a/src/settings/setting/changeDifficulty.ts
+++ b/src/settings/setting/changeDifficulty.ts
@@ -37,15 +37,22 @@ export default (
 						.setPlaceholder("price")
 						.setValue(String(diff.price))
 						.onChange(async (newPrice) => {
-							const index = context.plugin.settings.difficulties.findIndex(
-								(settingDiff) => settingDiff.name === diff.name,
-							);
-
-							context.plugin.settings.difficulties[index].price =
-								Number(newPrice);
-
-							await context.plugin.saveSettings();
-						}),
+                            const index = context.plugin.settings.difficulties.findIndex(
+                                (settingDiff) => settingDiff.name === diff.name,
+                            );
+                        
+                            context.plugin.settings.difficulties[index].price = Number(newPrice);
+                        
+                            await context.plugin.saveSettings();
+                        })
+                        .inputEl.addEventListener("blur", async () => {
+                            // Sort and re-render when input lose focus
+                            context.plugin.settings.difficulties.sort((a, b) => a.price - b.price);
+                            difficultyList.empty();
+                            refreshDifficulty();
+                            await context.plugin.saveSettings();
+                             
+                        })
 				)
 				.addButton((b) =>
 					b.setButtonText("x").onClick(async () => {

--- a/src/settings/setting/customizeGroups.ts
+++ b/src/settings/setting/customizeGroups.ts
@@ -19,7 +19,7 @@ export default (
             groupList.appendChild(groupItem);
 
             const generateMetadataInput =
-                (metadataField: keyof GroupMetadata) => (t: TextComponent) =>
+                (metadataField: keyof GroupMetadata) => (t: TextComponent): TextComponent =>
                     t
                         .setPlaceholder(metadataField)
                         .setValue(String(metadata[metadataField]))

--- a/src/settings/setting/showByStatus.ts
+++ b/src/settings/setting/showByStatus.ts
@@ -1,5 +1,5 @@
 import { StatusKeys } from "@core/consts";
-import { StatusFilterOption } from "@core/types";
+import { Status } from "@core/types";
 import GamifiedTasksSettingTab from "@settings";
 import { Setting } from "obsidian";
 
@@ -11,16 +11,45 @@ export default (
 
 	StatusKeys.forEach((status) => (statusFilterOptions[status] = status));
 
+	// Checkbox group for multi-select
 	new Setting(containerEl)
 		.setName("Default status filter")
-		.addDropdown((dropDown) =>
-			dropDown
-				.addOption("all", "all")
-				.addOptions(statusFilterOptions)
-				.setValue(context.plugin.settings.statusFilter)
-				.onChange(async (value) => {
-					context.plugin.settings.statusFilter = value as StatusFilterOption;
-					await context.plugin.saveSettings();
-				}),
-		);
+		.setDesc("Select one or more statuses as filter")
+		.setClass("gamified-tasks__status-checkbox-group")
+		.addExtraButton((btn) => {
+			btn.setIcon("checkmark")
+			.setTooltip("Save selected statuses")
+			.onClick(async () => {
+				await context.plugin.saveSettings();
+			});
+		});
+
+	const checkboxContainer = containerEl.createDiv();
+	StatusKeys.forEach((status) => {
+		const label = document.createElement("label");
+		label.style.marginRight = "1em";
+		const checkbox = document.createElement("input");
+		checkbox.type = "checkbox";
+		checkbox.value = status;
+		checkbox.checked = context.plugin.settings.statusFilter.includes(status as Status);
+		checkbox.onchange = async (e): Promise<void> => {
+			const isChecked = (e.target as HTMLInputElement).checked;
+			const filter = context.plugin.settings.statusFilter as Array<Status>;
+			if (isChecked) {
+				if (!filter.includes(status as Status)) {
+					filter.push(status as Status);
+				}
+			} else {
+				const idx = filter.indexOf(status as Status);
+				if (idx > -1) {
+					filter.splice(idx, 1);
+				}
+			}
+			context.plugin.settings.statusFilter = [...filter];
+			await context.plugin.saveSettings();
+		};
+		label.appendChild(checkbox);
+		label.appendChild(document.createTextNode(status));
+		checkboxContainer.appendChild(label);
+	});
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import {
     GroupMetadata,
     SortOrder,
     SortType,
-    StatusFilterOption,
+    Status,
     TaskFilterOptionsType
 } from "@core/types";
 
@@ -14,7 +14,7 @@ export type GamifiedTasksSettings = {
     pathToSaveNewTask: string;
 
     limit: number | undefined;
-    statusFilter: StatusFilterOption;
+    statusFilter: Array<Status>;
     isRecurTasks: boolean;
     tagFilter: string;
     hasOnlyThisTags: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export type GamifiedTasksSettings = {
     pathToSaveNewTask: string;
 
     limit: number | undefined;
-    statusFilter: Array<Status>;
+    statusFilter: Array<Status> | string;
     isRecurTasks: boolean;
     tagFilter: string;
     hasOnlyThisTags: boolean;

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,5 +1,5 @@
 import { HistoryRow } from "@hooks/useHistory";
-import { Task } from "@core/types";
+import { Status, Task } from "@core/types";
 import { GamifiedTasksSettings } from "@types";
 import { Workspace } from "obsidian";
 import { generatePastDaysArray, getAmountOfPastDays } from "./date";
@@ -68,21 +68,17 @@ export const byNote =
  * Use currying to set status filter and return callback to call in filter
  */
 export const byStatus =
-	(statusFilter: string) =>
+	(statusFilter: Array<Status>) =>
 		(task: Task): boolean => {
-			if (statusFilter === "all") {
-				return true;
-			}
-
 			if (!task.status) {
 				return false;
 			}
 
-			if (statusFilter === task.status) {
+			if (statusFilter.length === 0) {
 				return true;
 			}
 
-			return false;
+			return statusFilter.includes(task.status);
 		};
 
 /**

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -11,7 +11,7 @@ import { formatTasks } from "./string";
 /** Parse all occurance of task line in `file` content and then returns task list */
 export function parseTasksFromFile(file: RawFile): Array<Task> {
 	const tasks = file.content.reduce<Array<Task>>((acc, lineContent, index) => {
-		const regex = /- \[.\]/;
+		const regex = /^- \[.\] .+/;
 
 		if (lineContent.match(regex)) {
 			acc.push({

--- a/tests/difficulty.test.ts
+++ b/tests/difficulty.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert";
+import test, { describe } from "node:test";
+
+// Mock settings and functions for difficulty management
+type Difficulty = { name: string; price: number };
+
+type ChangeDifficultyParams = {
+  oldName: string;
+  newName: string;
+  newPrice: number;
+};
+
+function addDifficulty(difficulties: Array<Difficulty>, name: string, price: number): Array<Difficulty> {
+  return [...difficulties, { name, price }];
+}
+
+function changeDifficulty(
+  difficulties: Array<Difficulty>,
+  params: ChangeDifficultyParams
+): Array<Difficulty> {
+  const { oldName, newName, newPrice } = params;
+  return difficulties.map((diff) =>
+    diff.name === oldName ? { ...diff, name: newName, price: newPrice } : diff
+  );
+}
+
+describe("Difficulty management", () => {
+  test("add a new difficulty", () => {
+    const initial = [
+      { name: "easy", price: 1 },
+      { name: "medium", price: 2.5 },
+    ];
+    const updated = addDifficulty(initial, "hard", 5);
+    assert.strictEqual(updated.length, 3);
+    assert.deepStrictEqual(updated[2], { name: "hard", price: 5 });
+  });
+
+  test("change an existing difficulty's name and price", () => {
+    const initial = [
+      { name: "easy", price: 1 },
+      { name: "medium", price: 2.5 },
+    ];
+    const updated = changeDifficulty(initial, {
+      oldName: "easy",
+      newName: "super easy",
+      newPrice: 1.2,
+    });
+    assert.strictEqual(updated.length, 2);
+    assert.deepStrictEqual(updated[0], { name: "super easy", price: 1.2 });
+    assert.deepStrictEqual(updated[1], { name: "medium", price: 2.5 });
+  });
+});

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -1,0 +1,111 @@
+import { Task } from '@core/types';
+import { RawFile } from '../src/hooks/types';
+import assert from 'assert';
+import test, { describe, it } from "node:test";
+
+/** Parse all occurance of task line in `file` content and then returns task list */
+export function parseTasksFromFile(file: RawFile): Array<Task> {
+    const tasks = file.content.reduce<Array<Task>>((acc, lineContent, index) => {
+        const regex = /^- \[.\] .+/;
+
+        if (lineContent.match(regex)) {
+            acc.push({
+                path: file.path,
+                lineContent,
+                lineNumber: index,
+                body: lineContent,
+            });
+        }
+
+        return acc;
+    }, []);
+
+    return tasks;
+}
+
+describe('parseTasksFromFile', () => {
+  it('should return an empty array if no tasks are present', () => {
+    const file: RawFile = {
+      path: 'file.md',
+      content: [
+        'This is a line',
+        'Another line',
+        'Just text',
+      ],
+    };
+    const result = parseTasksFromFile(file);
+    assert.deepStrictEqual(result, []);
+  });
+
+  it('should parse single task line', () => {
+    const file: RawFile = {
+      path: 'tasks.md',
+      content: [
+        '- [ ] Task 1',
+        'Some other text',
+      ],
+    };
+    const result = parseTasksFromFile(file);
+    assert.strictEqual(result.length, 1);
+    assert.deepStrictEqual(result[0], {
+      path: 'tasks.md',
+      lineContent: '- [ ] Task 1',
+      lineNumber: 0,
+      body: '- [ ] Task 1',
+    });
+  });
+
+  it('should parse multiple task lines', () => {
+    const file: RawFile = {
+      path: 'tasks.md',
+      content: [
+        '- [ ] Task 1',
+        '- [x] Task 2',
+        'Not a task',
+        '- [ ] Task 3',
+      ],
+    };
+    const result = parseTasksFromFile(file);
+    assert.strictEqual(result.length, 3);
+    assert.deepStrictEqual(result.map(t => t.lineContent), [
+      '- [ ] Task 1',
+      '- [x] Task 2',
+      '- [ ] Task 3',
+    ]);
+  });
+
+  it('should assign correct line numbers', () => {
+    const file: RawFile = {
+      path: 'tasks.md',
+      content: [
+        'Intro',
+        '- [ ] Task 1',
+        'Middle',
+        '- [x] Task 2',
+        '- [ ] Task 3',
+      ],
+    };
+    const result = parseTasksFromFile(file);
+    assert.strictEqual(result[0].lineNumber, 1);
+    assert.strictEqual(result[1].lineNumber, 3);
+    assert.strictEqual(result[2].lineNumber, 4);
+  });
+  it('should not parse task if empty line content', () => {
+    const file: RawFile = {
+      path: 'tasks.md',
+      content: [
+        '- [ ] Task 1',
+        '',
+        '- [ ]',
+        'Not a task',
+        '- [ ] Task 3',
+      ],
+    };
+    const result = parseTasksFromFile(file);
+    assert.strictEqual(result.length, 2);
+    assert.deepStrictEqual(result.map(t => t.lineContent), [
+      '- [ ] Task 1',
+      '- [ ] Task 3',
+    ]);
+  });
+});


### PR DESCRIPTION
Hi, after using it for a while, the task status filter started to annoy me.

Initially, my use case was to filter for "all (except done)" statuses. To solve this, I developed a version that added excludeStatuses as an array type.
Then, I suddenly realized, why couldn't statusFilter itself become an array and selectable? My current use case is to show "todo," "doing," and "delay" statuses. Now, whenever I need to show "all", I simply untick them all – a more user-friendly approach.

![Screenshot 2025-04-19 at 17 57 17](https://github.com/user-attachments/assets/922f7a61-93d7-492b-808e-f66445016acf)

![Screenshot 2025-04-19 at 17 57 26](https://github.com/user-attachments/assets/8cbfdce9-6e66-4990-b336-1fb03eac6444)

Please note that the filter status is not saved, as you implemented it.

I also updated the regex to skip empty tasks, such as `- [ ]`.
